### PR TITLE
drop support for Nim v1.2/1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: i386
-        branch: [version-1-2, version-1-4, version-1-6, devel]
+        branch: [version-1-6, devel]
         include:
           - target:
               os: linux

--- a/kzg4844.nimble
+++ b/kzg4844.nimble
@@ -16,7 +16,7 @@ description   = "c-kzg-4844 wrapper in Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0"
+requires "nim >= 1.6.0"
 requires "stew >= 0.1.0"
 requires "unittest2"
 


### PR DESCRIPTION
There are not and cannot possibly have ever been legacy users of this library because it didn't exist.