### PR TITLE
Ensure compatibility with patched `blst.h` from `nim-blscurve`

### DIFF
--- a/kzg4844/c_kzg_4844.h
+++ b/kzg4844/c_kzg_4844.h
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2024 Status Research & Development GmbH
+ * Licensed under either of
+ *  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+ *  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+ * at your option.
+ * This file may not be copied, modified, or distributed except according to
+ * those terms.
+ */
+
+#ifndef C_KZG_4844_NIM_H
+#define C_KZG_4844_NIM_H
+
+// nim-blscurve redefines some function signatures for Nim compatibility
+// when using the blst backend. As kzg4844 also relies on blst, we have
+// to ensure that the same redefinitions are applied in case both modules
+// are imported by client logic.
+//
+// https://github.com/status-im/nim-blscurve/blob/master/blscurve/blst/blst%2Bnim.h
+
+// Nim does not support annotating pointer destinations with C `const`.
+//
+// This leads to errors on certain platforms and toolchains
+// when interacting with APIs involving nested pointers, e.g.:
+//     expected 'const blst_p1_affine * const*'
+//     but argument is of type 'blst_p1_affine **'
+//     [-Wincompatible-pointer-types]
+//
+// To prevent these issues, offending function signatures are replaced
+// with ones that lack C `const` annotations.
+
+#define blst_p1s_to_affine blst_p1s_to_affine_replaced
+#define blst_p1s_add blst_p1s_add_replaced
+#define blst_p1s_mult_wbits_precompute blst_p1s_mult_wbits_precompute_replaced
+#define blst_p1s_mult_wbits blst_p1s_mult_wbits_replaced
+#define blst_p1s_mult_pippenger blst_p1s_mult_pippenger_replaced
+#define blst_p1s_tile_pippenger blst_p1s_tile_pippenger_replaced
+
+#define blst_p2s_to_affine blst_p2s_to_affine_replaced
+#define blst_p2s_add blst_p2s_add_replaced
+#define blst_p2s_mult_wbits_precompute blst_p2s_mult_wbits_precompute_replaced
+#define blst_p2s_mult_wbits blst_p2s_mult_wbits_replaced
+#define blst_p2s_mult_pippenger blst_p2s_mult_pippenger_replaced
+#define blst_p2s_tile_pippenger blst_p2s_tile_pippenger_replaced
+
+#define blst_miller_loop_n blst_miller_loop_n_replaced
+
+#include "./csources/src/c_kzg_4844.h"
+
+#undef blst_p1s_to_affine
+#undef blst_p1s_add
+#undef blst_p1s_mult_wbits_precompute
+#undef blst_p1s_mult_wbits
+#undef blst_p1s_mult_pippenger
+#undef blst_p1s_tile_pippenger
+
+#undef blst_p2s_to_affine
+#undef blst_p2s_add
+#undef blst_p2s_mult_wbits_precompute
+#undef blst_p2s_mult_wbits
+#undef blst_p2s_mult_pippenger
+#undef blst_p2s_tile_pippenger
+
+#undef blst_miller_loop_n
+
+void blst_p1s_to_affine(blst_p1_affine dst[], blst_p1 *points[],
+                        size_t npoints);
+void blst_p1s_add(blst_p1 *ret, blst_p1_affine *points[],
+                                size_t npoints);
+void blst_p1s_mult_wbits_precompute(blst_p1_affine table[], size_t wbits,
+                                    blst_p1_affine *points[],
+                                    size_t npoints);
+void blst_p1s_mult_wbits(blst_p1 *ret, const blst_p1_affine table[],
+                         size_t wbits, size_t npoints,
+                         byte *scalars[], size_t nbits,
+                         limb_t *scratch);
+void blst_p1s_mult_pippenger(blst_p1 *ret, blst_p1_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch);
+void blst_p1s_tile_pippenger(blst_p1 *ret, blst_p1_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch,
+                             size_t bit0, size_t window);
+
+void blst_p2s_to_affine(blst_p2_affine dst[], blst_p2 *points[],
+                        size_t npoints);
+void blst_p2s_add(blst_p2 *ret, blst_p2_affine *points[],
+                                size_t npoints);
+void blst_p2s_mult_wbits_precompute(blst_p2_affine table[], size_t wbits,
+                                    blst_p2_affine *points[],
+                                    size_t npoints);
+void blst_p2s_mult_wbits(blst_p2 *ret, const blst_p2_affine table[],
+                         size_t wbits, size_t npoints,
+                         byte *scalars[], size_t nbits,
+                         limb_t *scratch);
+void blst_p2s_mult_pippenger(blst_p2 *ret, blst_p2_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch);
+void blst_p2s_tile_pippenger(blst_p2 *ret, blst_p2_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch,
+                             size_t bit0, size_t window);
+
+void blst_miller_loop_n(blst_fp12 *ret, blst_p2_affine *Qs[],
+                                        blst_p1_affine *Ps[],
+                                        size_t n);
+
+#endif

--- a/kzg4844/kzg.nim
+++ b/kzg4844/kzg.nim
@@ -1,11 +1,15 @@
 # nim-kzg4844
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+# Ensure "c_kzg_4844.h" in this directory takes precedence
+import std/[os, strutils]
+{.passc: "-I" & quoteShell(currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]).}
 
 {. warning[UnusedImport]:off .}
 

--- a/kzg4844/kzg_abi.nim
+++ b/kzg4844/kzg_abi.nim
@@ -1,11 +1,15 @@
 # nim-kzg4844
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+# Ensure "c_kzg_4844.h" in this directory takes precedence
+import std/[os, strutils]
+{.passc: "-I" & quoteShell(currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]).}
 
 import
   ./csources/bindings/nim/kzg_abi

--- a/kzg4844/kzg_ex.nim
+++ b/kzg4844/kzg_ex.nim
@@ -1,11 +1,15 @@
 # nim-kzg4844
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+# Ensure "c_kzg_4844.h" in this directory takes precedence
+import std/[os, strutils]
+{.passc: "-I" & quoteShell(currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]).}
 
 {. warning[UnusedImport]:off .}
 


### PR DESCRIPTION
When both `nim-kzg4844` and `nim-blscurve` are used, have to ensure that APIs related to Pippenger multiplication are patched consistently across both libraries.

- https://github.com/status-im/nim-blscurve/pull/178