### PR TITLE
add trusted setup constant

### DIFF
--- a/kzg4844/kzg.nim
+++ b/kzg4844/kzg.nim
@@ -18,4 +18,4 @@ import
   ./kzg_abi # compile sha256.c
 
 export
-  kzg
+  kzg, kzg_abi.trustedSetup

--- a/kzg4844/kzg_abi.nim
+++ b/kzg4844/kzg_abi.nim
@@ -9,17 +9,17 @@
 
 # Ensure "c_kzg_4844.h" in this directory takes precedence
 import std/[os, strutils]
-{.passc: "-I" & quoteShell(currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]).}
 
-import
-  ./csources/bindings/nim/kzg_abi
+const
+  currentDir = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
+  trustedSetup* =
+    staticRead(currentDir & "/csources/src/trusted_setup.txt")
 
-export
-  kzg_abi
+{.passc: "-I" & quoteShell(currentDir).}
+
+import ./csources/bindings/nim/kzg_abi
+
+export kzg_abi
 
 when defined(kzgExternalBlstNoSha256):
-  import std/strutils
-  from os import DirSep
-  const
-    kzgPath  = currentSourcePath.rsplit(DirSep, 1)[0] & "/"
-  {.compile: kzgPath & "sha256.c"}
+  {.compile: currentDir & "/sha256.c".}

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -10,8 +10,13 @@
 {.warning[UnusedImport]:off.}
 
 import
+  unittest2,
   ../kzg4844/kzg,
   ../kzg4844/kzg_abi
 
 # do nothing else, all tests are done in c-kzg-4844.
 # we only need to make sure our imports are compileable
+
+test "Check that trusted setup can be loaded":
+  check:
+    loadTrustedSetupFromString(trustedSetup, 0) == Result[void, string].ok()


### PR DESCRIPTION
This helps load the trusted setup whose location is relative to the kzg module, which can be fluid